### PR TITLE
Capitalize Keywords

### DIFF
--- a/internal/Start-DbccCheck.ps1
+++ b/internal/Start-DbccCheck.ps1
@@ -19,7 +19,7 @@ Function Start-DbccCheck {
 				Write-Verbose "Dbcc CheckTables finished successfully for $dbname on $servername"
 			}
 			else {
-				$null = $server.Query("dbcc checkdb ([$dbname])")
+				$null = $server.Query("DBCC CHECKDB ([$dbname])")
 				Write-Verbose "Dbcc CHECKDB finished successfully for $dbname on $servername"
 			}
 			return "Success"


### PR DESCRIPTION
Changed CheckDb to be in capitals. I asked in the slack and was told that uppercase was the preferred method.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Normalization of SQL.

### Approach
Keywords to be upper-case

