### PR TITLE
add ability to only pull one proxy

### DIFF
--- a/functions/Get-DbaAgentProxy.ps1
+++ b/functions/Get-DbaAgentProxy.ps1
@@ -11,7 +11,10 @@
 
         .PARAMETER SqlCredential
             Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
-
+        
+        .PARAMETER proxy
+            The proxy to process - this list is auto-populated from the server. If unspecified, all proxies will be processed.
+            
         .PARAMETER EnableException
             By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
             This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -41,6 +44,7 @@
         [Alias("ServerInstance", "Instance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
+        [object[]]$proxy
         [switch]$EnableException
     )
     process {
@@ -63,6 +67,10 @@
             $defaults = "ComputerName", "SqlInstance", "InstanceName", "Name", "ID", "CredentialID", "CredentialIdentity", "CredentialName", "Description", "IsEnabled"
             
             $proxies = $server.Jobserver.ProxyAccounts
+            
+            if ($proxy) {
+                $proxies = $proxies | Where-Object Name -In $proxy
+            }
             
             foreach ($proxy in $proxies) {
                 Add-Member -Force -InputObject $proxy -MemberType NoteProperty -Name ComputerName -value $server.ComputerName


### PR DESCRIPTION
I had a task recently where I had to pull all jobs and the proxies they ran under. This code would have helped immensely. Example taken from Get-DBAAgentJob

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ X ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Ability to pull back only one proxy account with this command.

### Approach
Add a parameter where you can specify proxy name.

### Commands to test
Only added functionality so shouldn't break anything else.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
